### PR TITLE
Enable .net3.5 if not present

### DIFF
--- a/fiddler/tools/chocolateyInstall.ps1
+++ b/fiddler/tools/chocolateyInstall.ps1
@@ -1,1 +1,12 @@
+$tools = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+function Is64Bit {  [IntPtr]::Size -eq 8  }
+
+if(Is64Bit) {$fx="framework64"} else {$fx="framework"}
+if(!(test-path "$env:windir\Microsoft.Net\$fx\v2.0.50727")) {
+  $packageArgs = "/c DISM /Online /NoRestart /Enable-Feature /FeatureName:NetFx3"
+  $statements = "cmd.exe $packageArgs"
+  Start-ChocolateyProcessAsAdmin "$statements" -minimized -nosleep -validExitCodes @(0,1)
+}
+
 Install-ChocolateyPackage 'fiddler' 'exe' '/S' '{{DownloadUrl}}'


### PR DESCRIPTION
Currently fiddler prompts the user on win 8/server 2012 if .net 2.0 is not enabled. This enables windows feature NetFx3 if it is not on the machine.
