### PR TITLE
Foobar2000 package was broken

### DIFF
--- a/foobar2000/foobar2000.nuspec
+++ b/foobar2000/foobar2000.nuspec
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>foobar2000</id>
     <title>foobar2000</title>
-    <version>{{PackageVersion}}</version>
+    <version>1.2.6.20130528</version>
     <authors>Peter Pawlowski</authors>
     <owners>Rob Reynolds</owners>
     <summary>foobar2000</summary>
@@ -12,6 +12,6 @@
     <tags>foobar2000 media player admin</tags>
     <licenseUrl>http://www.foobar2000.org/?page=License</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>http://www.foobar2000.org/button-large.png</iconUrl>
+    <iconUrl>https://raw.github.com/TomOne/chocolateyautomaticpackages/master/foobar2000/foobarlogo.png</iconUrl>
   </metadata>
 </package>

--- a/foobar2000/tools/Get-FilenameFromRegex.ps1
+++ b/foobar2000/tools/Get-FilenameFromRegex.ps1
@@ -1,0 +1,48 @@
+﻿# Redsandro - I will just include the required module in the package as long as it is not merged with Chocolatey
+
+# Some files have a changing element/hash in the download path, making an automated download harder.
+# This file gets the correct download url from a download page with a regular expression.
+# Good for e.g. Foobar2000, Rename Master, etc
+#
+# Usage: Get-FilenameFromRegex download_page find replace
+# Examples:
+# Get-FilenameFromRegex "http://www.joejoesoft.com/vcms/hot/userupload/8/files/rmv303.zip" '/cms/file.php\?f=userupload/8/files/rmv303.zip&amp;c=([\w\d]+)' 'http://www.joejoesoft.com/sim/$1/userupload/8/files/rmv303.zip'
+#
+# Remember to escape regex characters, like the question mark in the querystring
+
+function Get-FilenameFromRegex {
+	param(
+		[string]$source_url, 
+		[string]$find,
+		[string]$replace
+	)
+
+	try {
+
+		## Example # $source_url = "http://www.joejoesoft.com/vcms/hot/userupload/8/files/rmv303.zip"
+		## Example # $find = '/cms/file.php\?f=userupload/8/files/rmv303.zip&amp;c=([\w\d]+)'
+		## Example # $replace = 'http://www.joejoesoft.com/sim/$1/userupload/8/files/rmv303.zip'		
+
+		# Download and open download page
+		$tempfile = "$env:TEMP\chocolatey_temp_download.html"
+		$wc = new-object system.net.webclient
+		$wc.UseDefaultCredentials = $true
+		$wc.downloadfile($source_url, $tempfile)
+		$source = Get-Content $tempfile
+		
+		$nothing = ''+$source -cmatch $find # Get the matches, prevent output
+		# Replace Match-references with previous matches: $1 $2 -> $matches[1] $matches[2]
+		#$download_url = $replace -creplace "\$`(\d+)",$matches[$1]
+		# This one is not working :(
+		# I have a temporary fix that only allows ONE match. However, in most cases we only need one match.
+		$download_url = $replace -creplace "\$`(\d+)",$matches[1]
+        Remove-Item $tempfile
+
+		return $download_url
+		
+	} catch {
+		$errorMessage = "Could not get Regex from download page."
+		Write-Error $errorMessage
+		throw $errorMessage
+  }
+}

--- a/foobar2000/tools/chocolateyInstall.ps1
+++ b/foobar2000/tools/chocolateyInstall.ps1
@@ -1,3 +1,23 @@
-Install-ChocolateyPackage 'foobar2000' 'exe' '/S' '{{DownloadUrl}}' 
-#http://www.msfn.org/board/topic/39769-foobar2000-silent/
- 
+﻿try {
+
+    $packageName = "foobar2000"
+    $fileType = "exe"
+    $silentArgs = "/S"
+    $pwd = "$(split-path -parent $MyInvocation.MyCommand.Definition)"
+    
+	Import-Module "$($pwd)\Get-FilenameFromRegex.ps1"
+	# Why does an import failure on this module not throw an error?
+
+    $url1 = Get-FilenameFromRegex "http://www.filehippo.com/download_foobar2000/" 'download_foobar2000/download/([\w\d]+)/' 'http://www.filehippo.com/de/download_foobar2000/download/$1/'
+    Write-Host "Found URL which contains the download URL: $url1"
+
+	$url2 = Get-FilenameFromRegex "$url1" '/download/file/([\w\d]+)/' 'http://www.filehippo.com/download/file/$1/'
+	Write-Host "Found download URL: $url2"
+
+	Install-ChocolateyPackage $packageName $fileType $silentArgs $url2
+
+    Write-ChocolateySuccess $name
+} catch {
+  Write-ChocolateyFailure $name $($_.Exception.Message)
+  throw
+}


### PR DESCRIPTION
Hi Rob,
your foobar2000 package is broken. The download link specified in your package doesn’t work. I tried the new download link, which also contains a hash.
As you probably know, Redsandro wrote a nice function to obtain a hashed download link. But even with that function it isn’t possible to download foobar2000. I tried to use wget with a referer and a spoofed Firefox user agent. That also did not work. Then I looked if the download page sets a cookie, but it doesn’t. I also searched for a possible JavaScript code which generates the download link, but I didn’t find any.

Damn, either the site supervisor was very clever to prevent automated downloads or I have overlooked something.

Anyway, I still found a solution: I modified the function of Redsandro to work with FileHippo. Now the package automatically downloads the latest foobar2000 version from FileHippo.

Note that you should first push this package with the following tag in the nuspec: <version>1.2.6.20130528</version> Then you can replace it again with <version>{{PackageVersion}}</version> to work properly with Ketarin.

For the PackageVersion version variable you could use the title-tag from here: www.filehippo.com/download_foobar2000/

I hope you like my commit. But if you find a better solution, bring it on. :-)
