### PR TITLE
Better download link for dropbox package

### DIFF
--- a/dropbox/tools/chocolateyInstall.ps1
+++ b/dropbox/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = "dropbox"
 $filePath = "$env:TEMP\chocolatey\$packageName"
 $fileFullPath = "$filePath\$packageName`Install.exe"
-$url = "https://www.dropbox.com/download?plat=win"
+$url = 'https://dl-web.dropbox.com/u/17/Dropbox {{PackageVersion}}.exe'
 $fileType = "exe"
 $silentArgs = "/S"
 


### PR DESCRIPTION
The current download link in the Dropbox package doesn’t point to the latest version. For example, for several weeks it downloaded version 2.2.3 even if 2.2.8 was actual. Now it downloads 2.2.8 even if 2.2.9 is the latest. 
With the new download link from this PR we have the control over the version.
I already updated the Dropbox package in the Gallery to 2.2.9 and included this fix.
