### PR TITLE
Using the official release notes as version variable source for dropbox

### DIFF
--- a/dropbox/dropbox.xml
+++ b/dropbox/dropbox.xml
@@ -5,7 +5,7 @@
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
     <LastFileSize>34994736</LastFileSize>
-    <LastFileDate>2013-07-31T21:57:42.469264+02:00</LastFileDate>
+    <LastFileDate>2013-07-31T22:21:12.3779062</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -38,25 +38,11 @@
         <value>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>Textual</VariableType>
-            <Regex>[\d\.]+&lt;/a&gt;\s+&lt;span class="release_date"&gt;</Regex>
-            <Url>https://www.dropbox.com/release_notes</Url>
-            <TextualContent>{version-with-tags:regexreplace:([\d\.]+).+\n.+:$1}</TextualContent>
-            <Name>version</Name>
-          </UrlVariable>
-        </value>
-      </item>
-      <item>
-        <key>
-          <string>version-with-tags</string>
-        </key>
-        <value>
-          <UrlVariable>
-            <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>[\d\.]+&lt;/a&gt;\s+&lt;span class="release_date"&gt;</Regex>
+            <Regex>[\d\.]+(?=&lt;/a&gt;)</Regex>
             <Url>https://www.dropbox.com/release_notes</Url>
-            <Name>version-with-tags</Name>
+            <TextualContent />
+            <Name>version</Name>
           </UrlVariable>
         </value>
       </item>
@@ -71,7 +57,7 @@
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2013-07-31T21:57:42.5012659+02:00</LastUpdated>
+    <LastUpdated>2013-07-31T22:21:12.3779062</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
     <FixedDownloadUrl>https://dl-web.dropbox.com/u/17/Dropbox {version}.exe</FixedDownloadUrl>
     <Name>dropbox</Name>

--- a/dropbox/dropbox.xml
+++ b/dropbox/dropbox.xml
@@ -1,0 +1,79 @@
+﻿<?xml version='1.0' encoding='utf-8'?>
+<Jobs>
+  <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="1f53e631-2ada-419e-bb8d-f01b37daeaf5">
+    <WebsiteUrl />
+    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserNotes />
+    <LastFileSize>34994736</LastFileSize>
+    <LastFileDate>2013-07-31T21:57:42.469264+02:00</LastFileDate>
+    <IgnoreFileInformation>false</IgnoreFileInformation>
+    <DownloadBeta>Default</DownloadBeta>
+    <DownloadDate xsi:nil="true" />
+    <CheckForUpdatesOnly>false</CheckForUpdatesOnly>
+    <VariableChangeIndicator />
+    <CanBeShared>true</CanBeShared>
+    <ShareApplication>false</ShareApplication>
+    <ExclusiveDownload>false</ExclusiveDownload>
+    <HttpReferer />
+    <SetupInstructions />
+    <Variables>
+      <item>
+        <key>
+          <string>url64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>""</TextualContent>
+            <Name>url64</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex>[\d\.]+&lt;/a&gt;\s+&lt;span class="release_date"&gt;</Regex>
+            <Url>https://www.dropbox.com/release_notes</Url>
+            <TextualContent>{version-with-tags:regexreplace:([\d\.]+).+\n.+:$1}</TextualContent>
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>version-with-tags</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>[\d\.]+&lt;/a&gt;\s+&lt;span class="release_date"&gt;</Regex>
+            <Url>https://www.dropbox.com/release_notes</Url>
+            <Name>version-with-tags</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
+    <ExecuteCommand />
+    <ExecutePreCommand />
+    <ExecuteCommandType>Batch</ExecuteCommandType>
+    <ExecutePreCommandType>Batch</ExecutePreCommandType>
+    <Category />
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\Dropbox 2.2.12.exe</PreviousLocation>
+    <DeletePreviousFile>true</DeletePreviousFile>
+    <Enabled>true</Enabled>
+    <FileHippoId />
+    <LastUpdated>2013-07-31T21:57:42.5012659+02:00</LastUpdated>
+    <TargetPath>C:\Chocolatey\_work\</TargetPath>
+    <FixedDownloadUrl>https://dl-web.dropbox.com/u/17/Dropbox {version}.exe</FixedDownloadUrl>
+    <Name>dropbox</Name>
+  </ApplicationJob>
+</Jobs>


### PR DESCRIPTION
This Ketarin XML file uses the official Dropbox release notes as source for the version variable. With this we don’t have to rely on FileHippo and don’t have the typical delay of more than 3 days when a new Dropbox version gets released.
