### PR TITLE
Fixes unzipping of the mysql download

### DIFF
--- a/mysql/tools/chocolateyInstall.ps1
+++ b/mysql/tools/chocolateyInstall.ps1
@@ -37,7 +37,9 @@ try {
   $file = Join-Path $tempDir "$($packageName).zip"
   Get-ChocolateyWebFile "$packageName" "$file" "$url" "$url64"
 
-  Start-Process "7za" -ArgumentList "x -o`"$installDir`" -y `"$file`" -xr!docs -xr!mysql-test -xr!sql-bench -xr!supportfiles" -Wait
+  $zipDir = (dir $env:ChocolateyInstall\lib\7zip.commandline*)
+  if($zipDir.length -gt 0) {$zipDir = $zipDir[-1]}
+  &"$zipDir\tools\7za.exe" x -o$installDir -y "$file" -xr!docs -xr!mysql-test -xr!sql-bench -xr!supportfiles
 
   #find this directory
   $installedContentsDir = get-childitem $installDir -include 'mysql*' | Sort-Object -Property LastWriteTime -Desc | select -First 1


### PR DESCRIPTION
This seems like a very odd issue and I don't know if there is a better way to do this (I hope there is) but I've been slogging for a couple hours here with nothing better. 7zip is failing due to the quotes around the files. It works without quotes but that will break paths with spaces. I have tried tons of permutations of escaping with "", \"\", ^", ^`" and more. Tried using start-process, &, and tried with and without the batch redirect. Even if you go directly through the exe and do not use start-process, 7zip will fail with a quoted output path with spaces. It complains that the path does not exist although it does. It will work with a quoted archive with a space in the path. However, I could not get that to work with the batch redirect. So in the end, I find the exe and then just quote the archive. Unless someone customizes the chocolatey directory (rare) and then uses a path with spaces (much more rare), this should be fine.

I'm also assuming that this may have broken in a recent change to 7zip command line because it is odd that there have been so many downloads without many complaints. That said, if you could give the current package a try as a sanity check to see if it also fails for you, that would be more super duper than pooper scoopers.
