### PR TITLE
Fixed regex of sysinternals.ketarin.xml

### DIFF
--- a/sysinternals/sysinternals.ketarin.xml
+++ b/sysinternals/sysinternals.ketarin.xml
@@ -1,8 +1,7 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
 <Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="e4be5670-b13c-4600-9b08-d99e901734ad">
-    <SourceTemplate><![CDATA[<?xml version="1.0" encoding="utf-8"?>
-<Jobs>
+    <SourceTemplate><![CDATA[<Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="0fb30714-8ed0-4611-8f1b-cb8fec9dae91">
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
@@ -72,8 +71,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>13152110</LastFileSize>
-    <LastFileDate>2013-07-01T17:56:55+02:00</LastFileDate>
+    <LastFileSize>13284310</LastFileSize>
+    <LastFileDate>2013-12-18T23:05:00+01:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -144,7 +143,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>Textual</VariableType>
             <Regex />
-            <TextualContent>{date-numerical:regexreplace:(\d{2\}) (\d{2\}) (\d{4\}):$3.$1.$2}</TextualContent>
+            <TextualContent>{date-numerical:regexreplace:(\d{2\}) (\d{2\}),? (\d{4\}):$3.$1.$2}</TextualContent>
             <Name>date-iso8601</Name>
           </UrlVariable>
         </value>
@@ -160,7 +159,7 @@
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2013-07-08T15:31:19.5847015+02:00</LastUpdated>
+    <LastUpdated>2013-12-25T17:16:46.4011409+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
     <FixedDownloadUrl>http://download.sysinternals.com/files/SysinternalsSuite.zip</FixedDownloadUrl>
     <Name>sysinternals</Name>


### PR DESCRIPTION
In latest Sysinternals release, they added a comma after the day of the date (December 19, 2013). Because of that this package wasn’t updating automatically. This PR fixes it.

Merry Christmas!
