### PR TITLE
Fixed some broken packages

### DIFF
--- a/attributechanger/attributechanger.ketarin.xml
+++ b/attributechanger/attributechanger.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>4242486</LastFileSize>
-    <LastFileDate>2012-12-07T05:40:38.984044</LastFileDate>
+    <LastFileSize>3307203</LastFileSize>
+    <LastFileDate>2013-07-21T00:14:57+02:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -14,7 +14,7 @@
     <CanBeShared>true</CanBeShared>
     <ShareApplication>false</ShareApplication>
     <ExclusiveDownload>false</ExclusiveDownload>
-    <HttpReferer />
+    <HttpReferer>http://www.petges.lu/home/download/</HttpReferer>
     <SetupInstructions />
     <Variables>
       <item>
@@ -26,9 +26,10 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>http://www.petges.lu/download/</Url>
-            <StartText>&lt;span style="font-size:16px; "&gt;Attribute Changer </StartText>
-            <EndText>&lt;/span&gt; </EndText>
+            <Url>http://www.petges.lu/home/download/</Url>
+            <StartText>/uploads/ac.exe"&gt;Get Attribute Changer </StartText>
+            <EndText>&lt;/a&gt;</EndText>
+            <TextualContent />
             <Name>version</Name>
           </UrlVariable>
         </value>
@@ -44,9 +45,9 @@
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2012-12-07T05:40:38.984044</LastUpdated>
+    <LastUpdated>2014-01-05T16:31:13.4163256+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://www.petges.lu/download/ac.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>http://www.petges.lu/home/wp-content/uploads/ac.exe</FixedDownloadUrl>
     <Name>attributechanger</Name>
   </ApplicationJob>
 </Jobs>

--- a/attributechanger/tools/chocolateyInstall.ps1
+++ b/attributechanger/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-Install-ChocolateyPackage 'attributechanger' 'exe' '/SILENT' 'http://www.petges.lu/home/wp-content/uploads/ac.exe' 'http://www.petges.lu/home/wp-content/uploads/ac.exe'
+Install-ChocolateyPackage 'attributechanger' 'exe' '/SILENT' '{{DownloadUrl}}' '{{DownloadUrl}}'

--- a/filezilla.commandline/filezilla.commandline.ketarin.xml
+++ b/filezilla.commandline/filezilla.commandline.ketarin.xml
@@ -1,8 +1,7 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
 <Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="c79851b8-8077-4d88-b549-015482ca4542">
-    <SourceTemplate><![CDATA[<?xml version="1.0" encoding="utf-8"?>
-<Jobs>
+    <SourceTemplate><![CDATA[<Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="0fb30714-8ed0-4611-8f1b-cb8fec9dae91">
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
@@ -72,8 +71,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>7244002</LastFileSize>
-    <LastFileDate>2013-06-27T22:56:55+02:00</LastFileDate>
+    <LastFileSize>7241860</LastFileSize>
+    <LastFileDate>2013-08-07T22:12:26+02:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -123,13 +122,13 @@
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
     <SourceType>FixedUrl</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\FileZilla_3.7.1.1_win32.zip</PreviousLocation>
+    <PreviousLocation>C:\Chocolatey\_work\FileZilla_3.7.3_win32.zip</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2013-07-12T20:16:13.677556+02:00</LastUpdated>
+    <LastUpdated>2014-01-05T01:20:46.3217924+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://surfnet.dl.sourceforge.net/project/filezilla/FileZilla_Client/{version}/FileZilla_{version}_win32.zip</FixedDownloadUrl>
+    <FixedDownloadUrl>http://netcologne.dl.sourceforge.net/project/filezilla/FileZilla_Client/{version}/FileZilla_{version}_win32.zip</FixedDownloadUrl>
     <Name>filezilla.commandline</Name>
   </ApplicationJob>
 </Jobs>

--- a/filezilla.commandline/filezilla.commandline.ketarin.xml
+++ b/filezilla.commandline/filezilla.commandline.ketarin.xml
@@ -69,7 +69,7 @@
   </ApplicationJob>
 </Jobs>]]></SourceTemplate>
     <WebsiteUrl />
-    <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
+    <UserAgent />
     <UserNotes />
     <LastFileSize>7241860</LastFileSize>
     <LastFileDate>2013-08-07T22:12:26+02:00</LastFileDate>
@@ -93,9 +93,9 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>https://filezilla-project.org/download.php?show_all=1</Url>
-            <StartText>win32.zip/download"&gt;FileZilla_</StartText>
-            <EndText>_win32.zip</EndText>
+            <Url>http://sourceforge.net/projects/filezilla/files/FileZilla_Client/</Url>
+            <StartText>&lt;tr title="</StartText>
+            <EndText>" class="folder "&gt;</EndText>
             <TextualContent />
             <Name>version</Name>
           </UrlVariable>
@@ -103,15 +103,15 @@
       </item>
       <item>
         <key>
-          <string>url64</string>
+          <string>url</string>
         </key>
         <value>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>Textual</VariableType>
-            <Regex />
-            <TextualContent>""</TextualContent>
-            <Name>url64</Name>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>(?&lt;=ResponseUri: )[^\r\n]+</Regex>
+            <Url>http://sourceforge.net/projects/filezilla/files/FileZilla_Client/{version}/FileZilla_{version}_win32.zip/download</Url>
+            <Name>url</Name>
           </UrlVariable>
         </value>
       </item>
@@ -126,9 +126,9 @@
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2014-01-05T01:20:46.3217924+01:00</LastUpdated>
+    <LastUpdated>2014-01-29T19:34:15.8152882+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://netcologne.dl.sourceforge.net/project/filezilla/FileZilla_Client/{version}/FileZilla_{version}_win32.zip</FixedDownloadUrl>
+    <FixedDownloadUrl>{url}</FixedDownloadUrl>
     <Name>filezilla.commandline</Name>
   </ApplicationJob>
 </Jobs>

--- a/filezilla.commandline/tools/chocolateyInstall.ps1
+++ b/filezilla.commandline/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$packageName = 'filezilla.commandline'
-$url = 'http://sourceforge.net/projects/filezilla/files/FileZilla_Client/{{PackageVersion}}/FileZilla_{{PackageVersion}}_win32.zip/download'
+$url = '{{DownloadUrl}}'
 $unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 # Rename folder, otherwise the *.exe.gui and *.exe.ignore files wouldn’t have effect

--- a/filezilla/filezilla.ketarin.xml
+++ b/filezilla/filezilla.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent />
     <UserNotes />
-    <LastFileSize>4805933</LastFileSize>
-    <LastFileDate>2013-07-05T05:40:35.6401308</LastFileDate>
+    <LastFileSize>4812567</LastFileSize>
+    <LastFileDate>2013-08-07T22:12:23+02:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -31,20 +31,36 @@
           </UrlVariable>
         </value>
       </item>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url>http://sourceforge.net/projects/filezilla/files/FileZilla_Client/</Url>
+            <StartText>&lt;tr title="</StartText>
+            <EndText>" class="folder "&gt;</EndText>
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
     </Variables>
     <ExecuteCommand />
     <ExecutePreCommand />
     <ExecuteCommandType>Batch</ExecuteCommandType>
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
-    <SourceType>FileHippo</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\FileZilla_3.7.1.1_win32-setup.exe</PreviousLocation>
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\FileZilla_3.7.3_win32-setup.exe</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
-    <FileHippoId>filezilla</FileHippoId>
-    <LastUpdated>2013-07-05T05:40:35.6401308</LastUpdated>
+    <FileHippoId />
+    <LastUpdated>2014-01-05T01:20:23.0250441+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl />
+    <FixedDownloadUrl>http://netcologne.dl.sourceforge.net/project/filezilla/FileZilla_Client/{version}/FileZilla_{version}_win32-setup.exe</FixedDownloadUrl>
     <Name>filezilla</Name>
   </ApplicationJob>
 </Jobs>

--- a/filezilla/filezilla.ketarin.xml
+++ b/filezilla/filezilla.ketarin.xml
@@ -19,20 +19,6 @@
     <Variables>
       <item>
         <key>
-          <string>url64</string>
-        </key>
-        <value>
-          <UrlVariable>
-            <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>Textual</VariableType>
-            <Regex />
-            <TextualContent>""</TextualContent>
-            <Name>url64</Name>
-          </UrlVariable>
-        </value>
-      </item>
-      <item>
-        <key>
           <string>version</string>
         </key>
         <value>
@@ -47,6 +33,20 @@
           </UrlVariable>
         </value>
       </item>
+      <item>
+        <key>
+          <string>url</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>(?&lt;=ResponseUri: )[^\r\n]+</Regex>
+            <Url>http://sourceforge.net/projects/filezilla/files/FileZilla_Client/{version}/FileZilla_{version}_win32-setup.exe/download</Url>
+            <Name>url</Name>
+          </UrlVariable>
+        </value>
+      </item>
     </Variables>
     <ExecuteCommand />
     <ExecutePreCommand />
@@ -58,9 +58,9 @@
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2014-01-05T01:20:23.0250441+01:00</LastUpdated>
+    <LastUpdated>2014-01-29T19:27:54.4483652+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://netcologne.dl.sourceforge.net/project/filezilla/FileZilla_Client/{version}/FileZilla_{version}_win32-setup.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>{url}</FixedDownloadUrl>
     <Name>filezilla</Name>
   </ApplicationJob>
 </Jobs>

--- a/filezilla/tools/chocolateyInstall.ps1
+++ b/filezilla/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-Install-ChocolateyPackage 'filezilla' 'exe' '/S' 'http://downloads.sourceforge.net/filezilla/FileZilla_{{PackageVersion}}_win32-setup.exe'
+Install-ChocolateyPackage 'filezilla' 'exe' '/S' '{{DownloadUrl}}'

--- a/paint.net/paint.net.ketarin.xml
+++ b/paint.net/paint.net.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>3756544</LastFileSize>
-    <LastFileDate>2012-06-26T08:47:16.1519474</LastFileDate>
+    <LastFileSize>3739157</LastFileSize>
+    <LastFileDate>2013-08-17T22:02:31+02:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -31,20 +31,36 @@
           </UrlVariable>
         </value>
       </item>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url>http://www.dotpdn.com/downloads/pdn.html</Url>
+            <StartText>/files/Paint.NET.</StartText>
+            <EndText>.Install.zip</EndText>
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
     </Variables>
     <ExecuteCommand />
     <ExecutePreCommand />
     <ExecuteCommandType>Batch</ExecuteCommandType>
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
-    <SourceType>FileHippo</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\Paint.NET.3.5.10.Install.exe</PreviousLocation>
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\Paint.NET.3.5.11.Install.zip</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
-    <FileHippoId>paint.net</FileHippoId>
-    <LastUpdated>2012-06-26T08:47:16.1519474</LastUpdated>
+    <FileHippoId />
+    <LastUpdated>2014-01-05T01:13:39.1706408+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl />
+    <FixedDownloadUrl>http://www.dotpdn.com/files/Paint.NET.{version}.Install.zip</FixedDownloadUrl>
     <Name>paint.net</Name>
   </ApplicationJob>
 </Jobs>

--- a/paint.net/tools/chocolateyInstall.ps1
+++ b/paint.net/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 try {
 
   $toolsDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-  Install-ChocolateyZipPackage 'paint.net' 'http://www.dotpdn.com/files/Paint.NET.{{PackageVersion}}.Install.zip' $toolsDir
+  Install-ChocolateyZipPackage 'paint.net' '{{DownloadUrl}}' $toolsDir
 
   $paintFileFullPath = get-childitem $toolsDir -recurse -include *.exe | select -First 1
   Install-ChocolateyInstallPackage 'paint.net' 'exe' '/auto DESKTOPSHORTCUT=0' "$paintFileFullPath"

--- a/skype/skype.ketarin.xml
+++ b/skype/skype.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>1492584</LastFileSize>
-    <LastFileDate>2013-07-05T05:41:16.9678822</LastFileDate>
+    <LastFileSize>24993792</LastFileSize>
+    <LastFileDate>2013-11-14T18:12:39+01:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -16,20 +16,35 @@
     <ExclusiveDownload>false</ExclusiveDownload>
     <HttpReferer />
     <SetupInstructions />
-    <Variables />
+    <Variables>
+      <item>
+        <key>
+          <string>version</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>(?&lt;="Skype )[\d\.]+(?=")</Regex>
+            <Url>http://filehippo.com/download_skype/</Url>
+            <Name>version</Name>
+          </UrlVariable>
+        </value>
+      </item>
+    </Variables>
     <ExecuteCommand />
     <ExecutePreCommand />
     <ExecuteCommandType>Batch</ExecuteCommandType>
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
-    <SourceType>FileHippo</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\SkypeSetup.exe</PreviousLocation>
+    <SourceType>FixedUrl</SourceType>
+    <PreviousLocation>C:\Chocolatey\_work\SkypeSetup_6.11.0.102.msi</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
-    <FileHippoId>skype</FileHippoId>
-    <LastUpdated>2013-07-05T05:41:16.9678822</LastUpdated>
+    <FileHippoId />
+    <LastUpdated>2014-01-05T01:42:47.7813959+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl />
+    <FixedDownloadUrl>http://download.skype.com/msi/SkypeSetup_{version}.msi</FixedDownloadUrl>
     <Name>skype</Name>
   </ApplicationJob>
 </Jobs>

--- a/skype/tools/chocolateyInstall.ps1
+++ b/skype/tools/chocolateyInstall.ps1
@@ -5,7 +5,7 @@
 $packageName = "skype"
 $fileType = "msi"
 $silentArgs = "/qn /norestart"
-$url = "http://download.skype.com/msi/SkypeSetup_{{PackageVersion}}.msi"
+$url = '{{DownloadUrl}}'
 
 $processor = Get-WmiObject Win32_Processor
 $is64bit = $processor.AddressWidth -eq 64

--- a/vlc/tools/chocolateyInstall.ps1
+++ b/vlc/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿Install-ChocolateyPackage 'vlc' 'exe' '/S' 'http://cdn.mirror.garr.it/mirror3/mirrors/videolan/vlc/{{PackageVersion}}/win32/vlc-{{PackageVersion}}-win32.exe' 
+﻿Install-ChocolateyPackage 'vlc' 'exe' '/S' '{{DownloadUrl}}' 
 
 #http://cdn.mirror.garr.it/mirror3/mirrors/videolan/vlc/2.0.6/win32/vlc-2.0.6-win32.exe
 #'http://downloads.sourceforge.net/project/vlc/2.0.1/win32/vlc-2.0.1-win32.exe'

--- a/vlc/vlc.ketarin.xml
+++ b/vlc/vlc.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>22937227</LastFileSize>
-    <LastFileDate>2013-06-12T05:41:20.6562313</LastFileDate>
+    <LastFileSize>24097311</LastFileSize>
+    <LastFileDate>2013-12-09T01:38:32+01:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -40,9 +40,9 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>http://filehippo.com/download_vlc_32/</Url>
-            <StartText>Latest Version&lt;br/&gt;&lt;b&gt;VLC Media Player </StartText>
-            <EndText> (32-bit)&lt;/b&gt;</EndText>
+            <Url>https://www.videolan.org/vlc/</Url>
+            <StartText>/get.videolan.org/vlc/</StartText>
+            <EndText>/win32/vlc-</EndText>
             <Name>version</Name>
           </UrlVariable>
         </value>
@@ -54,11 +54,11 @@
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
     <SourceType>FixedUrl</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\vlc-2.0.7-win32.exe</PreviousLocation>
+    <PreviousLocation>C:\Chocolatey\_work\vlc-2.1.2-win32.exe</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId>vlc</FileHippoId>
-    <LastUpdated>2013-06-12T05:41:20.6562313</LastUpdated>
+    <LastUpdated>2014-01-05T01:24:25.6338666+01:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
     <FixedDownloadUrl>http://cdn.mirror.garr.it/mirror3/mirrors/videolan/vlc/{version}/win32/vlc-{version}-win32.exe</FixedDownloadUrl>
     <Name>vlc</Name>


### PR DESCRIPTION
This is a correction of https://github.com/ferventcoder/chocolateyautomaticpackages/pull/62

I fixed several broken packages. Most of them were broken because Filehippo changed its layout and therefore Ketarin is no longer able to use it. This makes the “FileHippo ID” functionality of Ketarin useless, see this this thread: https://ketarin.org/forum/topic/3403-updates-using-filehippo-id/

The fixed packages are:
- attributechanger (Was not broken, but I added the needed HTTP referer to the Ketarin job, so the file can be downloaded with Ketarin)
- filezilla (Used FileHippo ID)
- filezilla.commandline (Used SourceForge mirror was offline)
- paint.net (Used FileHippo ID)
- skype (Used FileHippo ID)
- vlc (Used FileHippo ID)
