### PR TITLE
Change filezilla server's download location

### DIFF
--- a/filezilla.server/filezilla.server.ketarin.xml
+++ b/filezilla.server/filezilla.server.ketarin.xml
@@ -78,7 +78,7 @@
     <FileHippoId />
     <LastUpdated>2012-05-23T03:39:28.3341549</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://hivelocity.dl.sourceforge.net/project/filezilla/FileZilla%20Server/{version}/FileZilla_Server-{versionUnderscore}.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>http://download.filezilla-project.org/FileZilla_Server-{versionUnderscore}.exe</FixedDownloadUrl>
     <Name>filezilla.server</Name>
   </ApplicationJob>
 </Jobs>

--- a/filezilla.server/tools/chocolateyInstall.ps1
+++ b/filezilla.server/tools/chocolateyInstall.ps1
@@ -27,7 +27,7 @@ try {
     Start-ChocolateyProcessAsAdmin "Copy-Item '$($toolsDir)\FileZilla Server.xml' '$fileZillaInstallDir' -Force"
   }
 
-  Install-ChocolateyPackage 'filezilla.server' 'exe' '/S' 'http://download.filezilla-project.org/FileZilla_Server-{{PackageVersion}}.exe'
+  Install-ChocolateyPackage 'filezilla.server' 'exe' '/S' 'http://downloads.sourceforge.net/filezilla/FileZilla_Server-{{PackageVersion}}.exe'
   
   Write-ChocolateySuccess 'filezilla.server'
 } catch {

--- a/filezilla.server/tools/chocolateyInstall.ps1
+++ b/filezilla.server/tools/chocolateyInstall.ps1
@@ -13,16 +13,18 @@ try {
   Start-sleep 8
 
   if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir)}
-  if (![System.IO.Directory]::Exists($fileZillaInstallDir)) {[System.IO.Directory]::CreateDirectory($fileZillaInstallDir)}
+  if (![System.IO.Directory]::Exists($fileZillaInstallDir)) {
+    Start-ChocolateyProcessAsAdmin "[System.IO.Directory]::CreateDirectory('$fileZillaInstallDir')" -validExitCodes @(0,-1073741510)
+  }
   
   if (![System.IO.File]::Exists("$($fileZillaInstallDir)\FileZilla Server Interface.xml")) {
     Write-Host "Copying FileZilla Server Interface.xml to install directory"
-    Copy-Item "$($toolsDir)\FileZilla Server Interface.xml" "$fileZillaInstallDir" -Force
+    Start-ChocolateyProcessAsAdmin "Copy-Item '$($toolsDir)\FileZilla Server Interface.xml' '$fileZillaInstallDir' -Force"
   }
   
   if (![System.IO.File]::Exists("$($fileZillaInstallDir)\FileZilla Server.xml")) {
     Write-Host "Copying FileZilla Server.xml to install directory"
-    Copy-Item "$($toolsDir)\FileZilla Server.xml" "$fileZillaInstallDir" -Force
+    Start-ChocolateyProcessAsAdmin "Copy-Item '$($toolsDir)\FileZilla Server.xml' '$fileZillaInstallDir' -Force"
   }
 
   Install-ChocolateyPackage 'filezilla.server' 'exe' '/S' 'http://download.filezilla-project.org/FileZilla_Server-{{PackageVersion}}.exe'

--- a/filezilla.server/tools/chocolateyInstall.ps1
+++ b/filezilla.server/tools/chocolateyInstall.ps1
@@ -25,7 +25,7 @@ try {
     Copy-Item "$($toolsDir)\FileZilla Server.xml" "$fileZillaInstallDir" -Force
   }
 
-  Install-ChocolateyPackage 'filezilla.server' 'exe' '/S' 'http://downloads.sourceforge.net/filezilla/FileZilla_Server-{{PackageVersion}}.exe'
+  Install-ChocolateyPackage 'filezilla.server' 'exe' '/S' 'http://download.filezilla-project.org/FileZilla_Server-{{PackageVersion}}.exe'
   
   Write-ChocolateySuccess 'filezilla.server'
 } catch {


### PR DESCRIPTION
Since July 1st, 2013, sf has established a new program called DevShare, meaning that (some? all?) installer packages downloaded from SF will be wrapped by a custom installer, which means that the filename of the download has changed (SFInstaller_SFFZ_filezilla_10770709_.exe) and is no loanger version dependent. Also the command line switches do no longer function as known, and a silent mode is not provided, at least not documented or known to me. As a result, this packages is no longer able to build the right download url and therefor fails to download the installation file. 

Fortunately, the filezilla project hosts its own copy which is the original installer, following the already-known naming pattern. I have modified the files to use this download instead of sourceforge's.
