### PR TITLE
Enhanced Dropbox package

### DIFF
--- a/dropbox/dropbox.nuspec
+++ b/dropbox/dropbox.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://github.com/ferventcoder/chocolateyautomaticpackages/raw/master/dropbox/dropbox.png</iconUrl>
     <dependencies>
-        <dependency id="autohotkey_l.portable" />
+        <dependency id="autohotkey.portable" />
     </dependencies>
   </metadata>
   <files>

--- a/dropbox/tools/chocolateyInstall.ps1
+++ b/dropbox/tools/chocolateyInstall.ps1
@@ -1,7 +1,10 @@
 ﻿$packageName = 'dropbox'
+$version = '{{PackageVersion}}'
+$uninstallRegistryPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\Dropbox'
 $filePath = "$env:TEMP\chocolatey\$packageName"
 $fileFullPath = "$filePath\${packageName}Install.exe"
 $url = 'https://dl-web.dropbox.com/u/17/Dropbox {{PackageVersion}}.exe'
+
 $fileType = 'exe'
 $silentArgs = '/S'
 
@@ -9,18 +12,33 @@ $silentArgs = '/S'
 $scriptPath = Split-Path -parent $MyInvocation.MyCommand.Definition
 $ahkFile = "$scriptPath\dropbox.ahk"
  
-try { 
-	if (-not (Test-Path $filePath)) {
-		New-Item $filePath -type directory
+try {
+
+	if (Test-Path $uninstallRegistryPath) {
+		$installedVersion = (Get-ItemProperty $uninstallRegistryPath).DisplayVersion
 	}
-	Get-ChocolateyWebFile $packageName $fileFullPath $url
-    Start-Process 'AutoHotkey' $ahkFile
-	Start-Process $fileFullPath $silentArgs
-	Wait-Process -Name "dropboxInstall"
-	Remove-Item $fileFullPath
+
+	if ($installedVersion -eq $version) {
+		Write-Host "Dropbox $version is already installed."
+	} else {
+
+        # Download and install Dropbox
+
+		if (-not (Test-Path $filePath)) {
+			New-Item $filePath -type directory
+		}
+
+		Get-ChocolateyWebFile $packageName $fileFullPath $url
+		Start-Process 'AutoHotkey' $ahkFile
+		Start-Process $fileFullPath $silentArgs
+		Wait-Process -Name "dropboxInstall"
+		Remove-Item $fileFullPath
+	}
 
 	Write-ChocolateySuccess $packageName
+
 } catch {
+
 	Write-ChocolateyFailure $packageName $($_.Exception.Message)
 	throw
 }

--- a/dropbox/tools/chocolateyUninstall.ps1
+++ b/dropbox/tools/chocolateyUninstall.ps1
@@ -1,0 +1,17 @@
+﻿try {
+
+    $packageName = 'dropbox'
+    $fileType = 'exe'
+    $silentArgs = '/S'
+    $uninstallerPath = Join-Path $env:APPDATA 'Dropbox\bin\DropboxUninstaller.exe'
+    
+    if (Test-Path $uninstallerPath) {
+        Uninstall-ChocolateyPackage $packageName $fileType $silentArgs $uninstallerPath
+    }
+
+    Write-ChocolateySuccess $packageName
+
+} catch {
+    Write-ChocolateyFailure $packageName $($_.Exception.Message)
+    throw
+}


### PR DESCRIPTION
- @AnthonyMastrean asked me to proceed with [autohotkey.portable](http://chocolatey.org/packages/autohotkey.portable) instead of [autohotkey_l.portable](http://chocolatey.org/packages/autohotkey_l.portable), because because that name is less confusing and also the packaged software itself does no longer use the term “AutoHotkey_L”. Therefore I adapted the dependency for the Dropbox package.
- Before installing, the Dropbox package now checks if the same version as in the package is already installed. If that is the case, the download and installation gets skipped, because it would be useless. Dropbox occasionally [auto-updates](https://www.dropbox.com/help/13/en) itself, so this scenario is not uncommon.
- Added uninstaller script

Of course I tested all this in my VM and it works fine.
