### PR TITLE
7-zip.install: use Measure-Object instead of .count for strict mode compliance

### DIFF
--- a/7zip.install/tools/chocolateyInstall.ps1
+++ b/7zip.install/tools/chocolateyInstall.ps1
@@ -1,11 +1,7 @@
 ﻿Function Get-ExplorerProcessCount
 {
     $process = Get-Process explorer -ErrorAction SilentlyContinue
-    $processCount = 0
-    if($process -ne $null)
-    {
-        $processCount = $process.count
-    }
+    $processCount = ($process | Measure-Object).Count
     return $processCount
 }
 


### PR DESCRIPTION
It won't hurt to fix the package, even if future Chocolatey would provide a workaround.
