### PR TITLE
Set path system wide when installing git.install.

### DIFF
--- a/git.commandline/tools/chocolateyInstall.ps1
+++ b/git.commandline/tools/chocolateyInstall.ps1
@@ -23,8 +23,8 @@ try {
   #& 7za x -o"$gitInstallDir" -y "$file"
   Start-Process "7za" -ArgumentList "x -o`"$gitInstallDir`" -y `"$file`"" -Wait
 
-  Install-ChocolateyPath $gitInstallDir 'Machine'
-  Install-ChocolateyPath "$($gitInstallDir)\cmd" 'Machine'
+  Install-ChocolateyPath $gitInstallDir 'user'
+  Install-ChocolateyPath "$($gitInstallDir)\cmd" 'user'
   
 #  Write-Host 'Making GIT core.autocrlf false'
 #  #make GIT core.autocrlf false

--- a/git.commandline/tools/chocolateyInstall.ps1
+++ b/git.commandline/tools/chocolateyInstall.ps1
@@ -23,8 +23,8 @@ try {
   #& 7za x -o"$gitInstallDir" -y "$file"
   Start-Process "7za" -ArgumentList "x -o`"$gitInstallDir`" -y `"$file`"" -Wait
 
-  Install-ChocolateyPath $gitInstallDir 'user'
-  Install-ChocolateyPath "$($gitInstallDir)\cmd" 'user'
+  Install-ChocolateyPath $gitInstallDir 'Machine'
+  Install-ChocolateyPath "$($gitInstallDir)\cmd" 'Machine'
   
 #  Write-Host 'Making GIT core.autocrlf false'
 #  #make GIT core.autocrlf false

--- a/git.install/tools/chocolateyInstall.ps1
+++ b/git.install/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ try {
   if ($is64bit) {$programFiles = ${env:ProgramFiles(x86)}}
   $gitPath = Join-Path $programFiles 'Git\cmd'
 
-  Install-ChocolateyPath $gitPath 'user'
+  Install-ChocolateyPath $gitPath 'Machine'
 
 #@"
 #


### PR DESCRIPTION
This is my first PR for chocolatey.

One question: where is the package version increase ? (i.e. in Debian we have upstream version + Debian package version, in order to trigger an update when we just update the package).
