### PR TITLE
(virtualbox) Always install $ENV:PROGRAMFILES to the PATH

### DIFF
--- a/virtualbox/tools/chocolateyInstall.ps1
+++ b/virtualbox/tools/chocolateyInstall.ps1
@@ -1,13 +1,13 @@
-$packageName = 'virtualbox'
-$tools="$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-Start-ChocolateyProcessAsAdmin "certutil -addstore 'TrustedPublisher' '$tools\oracle.cer'"
-Install-ChocolateyPackage $packageName 'exe' '-s -l -msiparams REBOOT=ReallySuppress' '{{DownloadUrl}}'
+$id = 'virtualbox'
+$url = '{{DownloadUrl}}'
+$kind = 'exe'
+$silent = '-s -l -msiparams REBOOT=ReallySuppress'
 
+$tools = Split-Path $MyInvocation.MyCommand.Definition
+$cert = Join-Path $tools 'oracle.cer'
+$bin = Join-Path $ENV:PROGRAMFILES 'Oracle\VirtualBox'
 
-$is64bit = (Get-WmiObject Win32_Processor).AddressWidth -eq 64
-$programFiles = $env:programfiles
-if ($is64bit) {$programFiles = ${env:ProgramFiles(x86)}}
-$fsObject = New-Object -ComObject Scripting.FileSystemObject
-$programFiles = $fsObject.GetFolder("$programFiles").ShortPath
+Start-ChocolateyProcessAsAdmin "certutil -addstore 'TrustedPublisher' '$cert'"
 
-Install-ChocolateyPath $(join-path $programFiles 'Oracle\VirtualBox')
+Install-ChocolateyPackage $id $kind $silent $url
+Install-ChocolateyPath $bin


### PR DESCRIPTION
Looks like VirtualBox installs to $ENV:PROGRAMFILES on 32- and 64-bit systems now. So, this change _should_ work, but I didn't test it end-to-end. I know I should have kept this commit smaller, but I had to break out some variables make sense of everything ;)
