### PR TITLE
Updating MySQL to take account of new installer location

### DIFF
--- a/mysql/mysql.ketarin.xml
+++ b/mysql/mysql.ketarin.xml
@@ -1,4 +1,4 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.0' encoding='utf-8'?>
 <Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="8776d40e-3513-4c06-9ca8-eb3f49f964df">
     <WebsiteUrl />
@@ -61,7 +61,7 @@
     <FileHippoId />
     <LastUpdated>2013-06-04T05:40:58.4619381</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://www.mysql.com/get/Downloads/MySQL-5.6/mysql-{version}-win32.msi/from/http://mysql.he.net/</FixedDownloadUrl>
+    <FixedDownloadUrl>http://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-{version}-win32.zip</FixedDownloadUrl>
     <Name>mysql</Name>
   </ApplicationJob>
 </Jobs>


### PR DESCRIPTION
The msi now has a different name and location on dev.mysql.com
Changed to zip file as its more consistant.
