### PR TITLE
Fix broken FileZilla package: change URL

### DIFF
--- a/filezilla/filezilla.ketarin.xml
+++ b/filezilla/filezilla.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent />
     <UserNotes />
-    <LastFileSize>4822473</LastFileSize>
-    <LastFileDate>2014-02-11T13:49:15-06:00</LastFileDate>
+    <LastFileSize>5981830</LastFileSize>
+    <LastFileDate>2014-07-22T11:59:22+02:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -33,6 +33,48 @@
           </UrlVariable>
         </value>
       </item>
+      <item>
+        <key>
+          <string>urlUsingMirror</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>RegularExpression</VariableType>
+            <Regex>(?&lt;=ResponseUri: )[^\r\n]+</Regex>
+            <Url>{properUrl}</Url>
+            <Name>urlUsingMirror</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>properUrl</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>http://sourceforge.net/projects/filezilla/files/FileZilla_Client/{version}/FileZilla_{version}_win32-setup.exe/download</TextualContent>
+            <Name>properUrl</Name>
+          </UrlVariable>
+        </value>
+      </item>
+      <item>
+        <key>
+          <string>url64</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>Textual</VariableType>
+            <Regex />
+            <TextualContent>{properUrl}</TextualContent>
+            <Name>url64</Name>
+          </UrlVariable>
+        </value>
+      </item>
     </Variables>
     <ExecuteCommand />
     <ExecutePreCommand />
@@ -40,13 +82,13 @@
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
     <SourceType>FixedUrl</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\FileZilla_3.7.4.1_win32-setup.exe</PreviousLocation>
+    <PreviousLocation>C:\Chocolatey\_work\FileZilla_3.9.0.1_win32-setup.exe</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2014-02-19T06:22:59.3699738-06:00</LastUpdated>
+    <LastUpdated>2014-07-25T20:00:28.2775441+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://download.filezilla-project.org/FileZilla_{version}_win32-setup.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>{urlUsingMirror}</FixedDownloadUrl>
     <Name>filezilla</Name>
   </ApplicationJob>
 </Jobs>

--- a/filezilla/tools/chocolateyInstall.ps1
+++ b/filezilla/tools/chocolateyInstall.ps1
@@ -1,1 +1,3 @@
-Install-ChocolateyPackage 'filezilla' 'exe' '/S' '{{DownloadUrl}}'
+﻿# {\{DownloadUrlx64}\} actually contains the URL to FileZilla 32-bit.
+
+Install-ChocolateyPackage 'filezilla' 'exe' '/S' '{{DownloadUrlx64}}'


### PR DESCRIPTION
Your FileZilla package is not updating anymore, because the installer (starting from 3.9.0) is now only downloadable via SourceForge. As you probably know, SourceForge is a bit tricky to use with Ketarin, because Ketarin lacks of following HTTP 301/302 redirects which are used there.

I had to “misuse” the `{{DownloadUrlx64}}` substitution variable as 32-bit download URL, otherwise the package would contain a specific mirror URL, which is bad (not all mirrors aren’t always online and some are slow sometimes).

No worries about the adware that was bundled with the FileZilla installer on Windows some time ago. The installer is now adware-free.
